### PR TITLE
修复了README中的链接格式错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 使用Go实现的GHProxy,用于加速部分地区Github仓库的拉取,支持速率限制,用户鉴权,支持Docker部署
 
-[DEMO](ghproxy.1888866.xyz)
+[DEMO](https://ghproxy.1888866.xyz)
 
 ## 项目说明
 


### PR DESCRIPTION
本次修改修复了README中的链接格式错误，将DEMO链接修改为正确的URL格式，以确保用户能够正确访问到演示页面。