### PR TITLE
Remove version specification from docker-compose.yml

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
     ghproxy:
         image: 'wjqserver/ghproxy:latest'


### PR DESCRIPTION
`version` is obsolete as described in https://docs.docker.com/reference/compose-file/version-and-name/

Removing this can prevent warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新增内容
  - 无

- Bug 修复
  - 无

- 维护/杂项
  - 更新 Docker Compose 配置，移除顶层版本声明，提升与新版 Compose 的兼容性并减少启动警告。
  - 现有服务、端口映射与卷挂载保持不变，部署与启动流程不受影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->