### PR TITLE
test(auth): cover hyphenated whitelist owner matching

### DIFF
--- a/auth/whitelist_test.go
+++ b/auth/whitelist_test.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ghproxy/config"
+)
+
+func TestSplitUserRepoWhitelist_PreservesHyphenatedOwner(t *testing.T) {
+	user, repo := splitUserRepoWhitelist("jow-/ucode")
+
+	if user != "jow-" {
+		t.Fatalf("user = %q, want %q", user, "jow-")
+	}
+	if repo != "ucode" {
+		t.Fatalf("repo = %q, want %q", repo, "ucode")
+	}
+}
+
+func TestInitWhitelist_AllowsHyphenatedOwnerRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	whitelistPath := filepath.Join(tmpDir, "whitelist.json")
+
+	content := []byte(`{"whitelist":["jow-/ucode"]}`)
+	if err := os.WriteFile(whitelistPath, content, 0o600); err != nil {
+		t.Fatalf("write whitelist file: %v", err)
+	}
+
+	whitelistInstance = nil
+	whitelistInitErr = nil
+
+	cfg := &config.Config{}
+	cfg.Whitelist.WhitelistFile = whitelistPath
+
+	if err := InitWhitelist(cfg); err != nil {
+		t.Fatalf("InitWhitelist() error = %v", err)
+	}
+
+	if !CheckWhitelist("jow-", "ucode") {
+		t.Fatal("CheckWhitelist() = false, want true for jow-/ucode")
+	}
+
+	if CheckWhitelist("jow", "ucode") {
+		t.Fatal("CheckWhitelist() = true, want false for non-hyphenated owner")
+	}
+
+	if CheckWhitelist("jow-", "other") {
+		t.Fatal("CheckWhitelist() = true, want false for unmatched repo")
+	}
+
+	t.Cleanup(func() {
+		whitelistInstance = nil
+		whitelistInitErr = nil
+	})
+}


### PR DESCRIPTION
## Summary
- add regression tests for whitelist entries with hyphenated owners such as `jow-/ucode`
- verify both parsing and `CheckWhitelist` matching preserve the trailing hyphen in the owner name
- document, via executable tests, that issue #184 is not reproducible on current `main`

## Testing
- `go test ./auth -run 'Test(SplitUserRepoWhitelist_PreservesHyphenatedOwner|InitWhitelist_AllowsHyphenatedOwnerRepo)$'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 为白名单处理功能添加单元测试，验证支持带连字符的所有者和仓库名称的正确解析，确保白名单检查功能运行正常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->